### PR TITLE
Add support for LEGO Duplo Hub No. 16 (interactive-adventure-train-10427)

### DIFF
--- a/src/Lpf2Hub.cpp
+++ b/src/Lpf2Hub.cpp
@@ -98,6 +98,9 @@ public:
                     case DUPLO_TRAIN_HUB_ID:
                         _lpf2Hub->_hubType = HubType::DUPLO_TRAIN_HUB;
                         break;
+                    case DUPLO_TRAIN_HUB_2_ID:
+                        _lpf2Hub->_hubType = HubType::DUPLO_TRAIN_HUB_2;
+                        break;
                     case BOOST_MOVE_HUB_ID:
                         _lpf2Hub->_hubType = HubType::BOOST_MOVE_HUB;
                         break;
@@ -660,6 +663,8 @@ byte Lpf2Hub::getModeForDeviceType(byte deviceType)
         return (byte)HubPropertyOperation::ENABLE_UPDATES_DOWNSTREAM;
     case (byte)DeviceType::MARIO_HUB_GESTURE_SENSOR:
         return 0x01;
+    case (byte)DeviceType::DUPLO_TRAIN_HUB16_LIGHT_SPEAKER:
+        return 0x01;
     default:
         return 0x00;
     }
@@ -794,6 +799,7 @@ void Lpf2Hub::notifyCallback(
         break;
     }
     case (byte)MessageType::PORT_VALUE_SINGLE:
+    case (byte)MessageType::PORT_VALUE_COMBINEDMODE:
     {
         parseSensorMessage(pData);
         break;
@@ -1393,6 +1399,44 @@ void Lpf2Hub::playTone(byte number)
     WriteValue(setToneMode, 8);
     byte playTone[6] = {0x81, 0x01, 0x11, 0x51, 0x02, number};
     WriteValue(playTone, 6);
+}
+
+/**
+ * @brief Set the light colour on a Duplo Hub No. 16 (Hub No. 16, BLE type 0x21)
+ * @param [in] port port number - use DuploTrainHub2Port::LIGHT_SPEAKER (0x34)
+ * @param [in] color one of the Color enum values
+ * Command format confirmed via Wireshark capture of official LEGO Powered Up app.
+ */
+void Lpf2Hub::setHub16LightColor(byte port, DuploTrainHub16Color color)
+{
+    byte command[9] = {0x81, port, 0x11, 0x51, 0x01, 0x04, 0x01, (byte)color, 0x00};
+    WriteValue(command, 9);
+}
+
+/**
+ * @brief Play a sound on a Duplo Hub No. 16 (Hub No. 16, BLE type 0x21)
+ * @param [in] port port number - use DuploTrainHub2Port::LIGHT_SPEAKER (0x34)
+ * @param [in] sound sound index - use DuploTrainHub16Sound enum (e.g. HORN = 1)
+ * Command format confirmed via Wireshark capture of official LEGO Powered Up app.
+ */
+void Lpf2Hub::playHub16Sound(byte port, byte sound)
+{
+    byte command[9] = {0x81, port, 0x11, 0x51, 0x01, sound, 0x01, 0x00, 0x00};
+    WriteValue(command, 9);
+}
+
+/**
+ * @brief Set the scene triggered when the train crosses the purple action tile
+ * on a Duplo Hub No. 16 (Hub No. 16, BLE type 0x21). This is a configuration
+ * command — it does not trigger the scene immediately.
+ * @param [in] port port number - use DuploTrainHub2Port::LIGHT_SPEAKER (0x34)
+ * @param [in] scene scene index - use DuploTrainHub16Scene enum
+ * Command format confirmed via Android HCI snoop of official LEGO Powered Up app.
+ */
+void Lpf2Hub::setHub16TileScene(byte port, byte scene)
+{
+    byte command[9] = {0x81, port, 0x11, 0x51, 0x01, 0x06, 0x01, scene, 0x00};
+    WriteValue(command, 9);
 }
 
 /**

--- a/src/Lpf2Hub.h
+++ b/src/Lpf2Hub.h
@@ -92,6 +92,10 @@ public:
   void playTone(byte number);
   void setMarioVolume(byte volume);
 
+  void setHub16LightColor(byte port, DuploTrainHub16Color color);
+  void playHub16Sound(byte port, byte sound);
+  void setHub16TileScene(byte port, byte scene);
+
   // parse methods to read in the message content of the charachteristic value
   void parseDeviceInfo(uint8_t *pData);
   void parsePortMessage(uint8_t *pData);

--- a/src/Lpf2HubConst.h
+++ b/src/Lpf2HubConst.h
@@ -34,12 +34,14 @@ enum struct HubType
   POWERED_UP_REMOTE = 4,
   DUPLO_TRAIN_HUB = 5,
   CONTROL_PLUS_HUB = 6,
-  MARIO_HUB = 7
+  MARIO_HUB = 7,
+  DUPLO_TRAIN_HUB_2 = 8  // Hub No. 16 (0x21)
 };
 
 enum BLEManufacturerData
 {
   DUPLO_TRAIN_HUB_ID = 32,   //0x20
+  DUPLO_TRAIN_HUB_2_ID = 33, //0x21 - Hub No. 16
   BOOST_MOVE_HUB_ID = 64,    //0x40
   POWERED_UP_HUB_ID = 65,    //0x41
   POWERED_UP_REMOTE_ID = 66, //0x42
@@ -106,7 +108,9 @@ enum struct DeviceType
   MARIO_HUB_BARCODE_SENSOR = 73,          // https://github.com/bricklife/LEGO-Mario-Reveng
   MARIO_HUB_PANT_SENSOR = 74,             // https://github.com/bricklife/LEGO-Mario-Reveng
   TECHNIC_MEDIUM_ANGULAR_MOTOR_GREY = 75, // Mindstorms
-  TECHNIC_LARGE_ANGULAR_MOTOR_GREY = 76   // Mindstorms
+  TECHNIC_LARGE_ANGULAR_MOTOR_GREY = 76,  // Mindstorms
+  DUPLO_TRAIN_HUB16_LIGHT_SPEAKER = 90,   // Hub No. 16 port 0x34 - confirmed: controls light colour and plays horn sound
+  DUPLO_TRAIN_HUB2_DEVICE_91 = 91         // Hub No. 16 port 0x33 - device type unconfirmed
 };
 
 enum struct MessageType
@@ -319,6 +323,54 @@ enum struct DuploTrainHubPort
   COLOR = 0x12,
   SPEEDOMETER = 0x13,
   VOLTAGE = 0x14
+};
+
+// Hub No. 16 (BLE type 0x21) - LEGO label "DUPLO HUB NO. 16"
+// Ports differ from classic DuploTrainHub
+enum struct DuploTrainHub2Port
+{
+  MOTOR = 0x32,
+  UNKNOWN_91 = 0x33,    // device 91 - function unconfirmed
+  LIGHT_SPEAKER = 0x34, // device 90 - controls light colour and hub sounds (horn etc.)
+  VOLTAGE = 0x35,
+  SPEEDOMETER = 0x36
+};
+
+// Colours for Hub No. 16 LIGHT_SPEAKER port (port 0x34)
+// Indices differ from the standard Color enum — use this enum for setHub16LightColor()
+// Matches the official LEGO Powered Up app cycle order
+enum struct DuploTrainHub16Color
+{
+  OFF    = 0,
+  WHITE  = 1,
+  RED    = 11,  // 0x0b
+  YELLOW = 8,
+  GREEN  = 7,
+  BLUE   = 9,
+  PURPLE = 10
+};
+
+// Sub-command summary for Hub No. 16 LIGHT_SPEAKER port (port 0x34), mode 0x01
+// Command format: {0x81, port, 0x11, 0x51, 0x01, sub_cmd, 0x01, param, 0x00}
+//   SET_COLOR (0x04): param = DuploTrainHub16Color
+//   PLAY_SCENE (0x06): param = DuploTrainHub16Scene
+//   HORN (0x07): param = 0x00
+
+enum struct DuploTrainHub16Sound
+{
+  HORN = 7
+};
+
+// Scene indices confirmed via Android HCI snoop of official LEGO Powered Up app
+// (purple action tile options). Index 0x02 is believed to be a custom recorded
+// sound — not implemented here.
+enum struct DuploTrainHub16Scene
+{
+  SCENE_DEFAULT = 0,
+  ISLAND        = 1,
+  NIGHT         = 3,
+  BIRTHDAY      = 4,
+  RAIN          = 5
 };
 
 enum struct MoveHubPort

--- a/src/Lpf2HubEmulation.cpp
+++ b/src/Lpf2HubEmulation.cpp
@@ -435,6 +435,12 @@ void Lpf2HubEmulation::start()
     const char controlPlusHub[8] = {0x97, 0x03, 0x00, 0x80, 0x06, 0x00, 0x41, 0x00};
     manufacturerData = std::string(controlPlusHub, sizeof(controlPlusHub));
   }
+  else if (_hubType == HubType::DUPLO_TRAIN_HUB_2)
+  {
+    log_d("Duplo Train Hub 2 (Hub No. 16)");
+    const char duploTrainHub2[8] = {(char)0x97, 0x03, 0x00, 0x21, 0x02, (char)0xff, 0x01, 0x00};
+    manufacturerData = std::string(duploTrainHub2, sizeof(duploTrainHub2));
+  }
   NimBLEAdvertisementData advertisementData = NimBLEAdvertisementData();
   // flags must be present to make PoweredUp working on devices with Android >=6
   // (however it seems to be not needed for devices with Android <6)


### PR DESCRIPTION
- [x] The code in this PR was LLM generated

- [x] I've tested the code and the code is working

- [x] I have no expectations this PR will be reviewed or merged, but hopefully it helps

  ## Summary

  Adds library support for the LEGO Duplo Hub No. 16 (model label
  "HUB NO. 16 IC3072A-103651", BLE manufacturer data type byte 0x21).

  This hub uses the same LPF2 BLE service UUID as existing hubs but has
  a different port layout, device types, and command format to the
  original Duplo Train Hub (0x20).

  All commands and port assignments were confirmed by capturing Android
  Bluetooth HCI snoop logs of the official app and
  verified on hardware (ESP32-C6).

  Notes

  - Motor speed is variable pn the newer models as well
  - Tile/scene detection is handled entirely by onboard firmware reading
  tile colour and length — no BLE notification is sent when a tile is
  crossed
  - Device type 91 (port 0x33) has not been identified; it is registered
  in the port map but no commands targeting it were observed in app
  traffic